### PR TITLE
Avoid fire the change event when has no value change

### DIFF
--- a/assets/live_phone.js
+++ b/assets/live_phone.js
@@ -90,8 +90,11 @@ class LivePhone {
   // back-end. So this sends a dummy change event to work around it.
   setChange({value: phone}) {
     const changeEvent = new Event('change', {bubbles: true})
-    this.elements.hiddenField().value = phone
-    this.elements.hiddenField().dispatchEvent(changeEvent)
+    const changed = this.elements.hiddenField().value !== phone
+    if (changed) {
+      this.elements.hiddenField().value = phone
+      this.elements.hiddenField().dispatchEvent(changeEvent)
+    }
   }
 
   // This updates the mask


### PR DESCRIPTION
When the component is mount in the screen the hook fire the change event without any change.

This will avoid this behavior.