### PR TITLE
Add missing `nil` in the util function spec

### DIFF
--- a/lib/live_phone/util.ex
+++ b/lib/live_phone/util.ex
@@ -94,7 +94,7 @@ defmodule LivePhone.Util do
       {:ok, "+16502530000"}
 
   """
-  @spec normalize(String.t(), String.t()) :: {:ok, String.t()} | {:error, String.t()}
+  @spec normalize(String.t(), String.t() | nil) :: {:ok, String.t()} | {:error, String.t()}
   def normalize(phone, country) do
     phone
     |> String.replace(~r/[^+\d]/, "")


### PR DESCRIPTION
In the sample function examples, we can pass `nil` to the normalize function, but this is missing from the spec.